### PR TITLE
Fixed issue with statically named security groups.

### DIFF
--- a/security-groups.tf
+++ b/security-groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "hashistack_server" {
-  name        = "hashistack-server-sg"
+  name        = "${var.ssh_key_name}-hashistack-server-sg"
   description = "Security Group for HashiStack Server Instances"
   vpc_id      = "${var.vpc_id}"
 
@@ -106,7 +106,7 @@ resource "aws_security_group" "hashistack_server" {
 }
 
 resource "aws_security_group" "consul_client" {
-  name        = "consul-client-sg"
+  name        = "${var.ssh_key_name}-consul-client-sg"
   description = "Security Group for Consul Client Instances"
   vpc_id      = "${var.vpc_id}"
 


### PR DESCRIPTION
There was a problem with running the same apply in a region with another HashiStack running as it was setting statically named security groups.  Changed the naming to add in the ssh-key name var as this should be different for every person.