### PR TITLE
Removed consul RPC 8400, added Nomad Serf UDP 4648

### DIFF
--- a/security-groups.tf
+++ b/security-groups.tf
@@ -80,14 +80,6 @@ resource "aws_security_group" "hashistack_server" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # RPC Consul
-  ingress {
-    from_port   = 8400
-    to_port     = 8400
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   # UDP All outbound traffic
   egress {
     from_port   = 0
@@ -139,14 +131,6 @@ resource "aws_security_group" "consul_client" {
     self      = true
   }
 
-  # RPC
-  ingress {
-    from_port = 8400
-    to_port   = 8400
-    protocol  = "tcp"
-    self      = true
-  }
-
   # Nomad RPC
   ingress {
     from_port = 4647
@@ -155,11 +139,19 @@ resource "aws_security_group" "consul_client" {
     self      = true
   }
 
-  # Nomad Serf
+  # Nomad Serf (TCP)
   ingress {
     from_port = 4648
     to_port   = 4648
     protocol  = "tcp"
+    self      = true
+  }
+
+  # Nomad Serf (UDP)
+  ingress {
+    from_port = 4648
+    to_port   = 4648
+    protocol  = "udp"
     self      = true
   }
 


### PR DESCRIPTION
The Consul RPC client interface was removed in Consul 0.8.0. Since then, the Consul CLI uses the HTTP API port (default  8500).  So, I removed both ingress rules for port 8400.

Additionally, the Nomad Serf port (default 4648) is used on both TCP and UDP, so I added an additional UDP ingress rule for this port.  See https://www.nomadproject.io/docs/agent/configuration/index.html#serf-2